### PR TITLE
feat: add option to maintain a copy of the last input color

### DIFF
--- a/src/colorTranslator.ts
+++ b/src/colorTranslator.ts
@@ -69,7 +69,7 @@ export default class ColorTranslator {
     spaced: true,
     limitToColorSpace: true,
     maxDigits: 2,
-    cacheInput: false,
+    cacheInput: true,
   };
   private _lastInput?: { format: ColorFormat; color: ColorInput };
 
@@ -79,7 +79,10 @@ export default class ColorTranslator {
   ) {
     this._options = merge(this._options, options);
 
-    this._rgb = colorToRgb100(color);
+    const { rgb100, format, standardizedColor } = colorToRgb100(color);
+
+    this.setCachedInput(format, standardizedColor);
+    this._rgb = rgb100;
   }
 
   cachedInput(format: ColorFormat) {

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -21,8 +21,8 @@ import {
   LCH,
   OKLAB,
   OKLCH,
-  Options,
   RGB,
+  StringOptions,
   ValuesArray,
 } from "./types";
 import { degToGrad, degToRad, degToTurn } from "./utils";
@@ -40,7 +40,7 @@ function genericToString(
   format: ColorFormat,
   values: ValuesArray,
   _alpha: number,
-  { legacy, spaced, maxDigits }: Options
+  { legacy, spaced, maxDigits }: StringOptions
 ) {
   const alpha = round(_alpha, maxDigits);
 
@@ -69,7 +69,7 @@ function genericToString(
   })`;
 }
 
-function stringifyDeg(angle: number, options: Options) {
+function stringifyDeg(angle: number, options: StringOptions) {
   const { maxDigits, angleUnit } = options;
   switch (angleUnit) {
     case AngleUnit.GRAD:
@@ -88,7 +88,7 @@ function stringifyDeg(angle: number, options: Options) {
 
 export function rgbToString(
   this: RGB<number> & GetColor,
-  customOptions: Partial<Options> = {}
+  customOptions: Partial<StringOptions> = {}
 ) {
   const { options } = this;
   const stringOptions = merge(options, customOptions);
@@ -110,7 +110,7 @@ export function rgbToString(
 
 export function hslToString(
   this: HSL<number> & GetColor,
-  customOptions: Partial<Options> = {}
+  customOptions: Partial<StringOptions> = {}
 ) {
   const { options } = this;
   const stringOptions = merge(options, customOptions);
@@ -135,7 +135,7 @@ export function hslToString(
 
 export function hwbToString(
   this: HWB<number> & GetColor,
-  customOptions: Partial<Options> = {}
+  customOptions: Partial<StringOptions> = {}
 ) {
   const { options } = this;
   const stringOptions = merge(options, customOptions);
@@ -159,7 +159,7 @@ export function hwbToString(
 
 export function labToString(
   this: LAB<number> & GetColor,
-  customOptions: Partial<Options> = {}
+  customOptions: Partial<StringOptions> = {}
 ) {
   const { options } = this;
   const stringOptions = merge(options, customOptions);
@@ -179,7 +179,7 @@ export function labToString(
 
 export function lchToString(
   this: LCH<number> & GetColor,
-  customOptions: Partial<Options> = {}
+  customOptions: Partial<StringOptions> = {}
 ) {
   const { options } = this;
   const stringOptions = merge(options, customOptions);
@@ -199,7 +199,7 @@ export function lchToString(
 
 export function hexToString(
   this: HEX & GetColor,
-  customOptions: Partial<Options> = {},
+  customOptions: Partial<StringOptions> = {},
   is0x = false
 ) {
   const { options } = this;
@@ -221,14 +221,14 @@ export function hexToString(
 
 export function hex0xToString(
   this: HEX & GetColor,
-  customOptions: Partial<Options> = {}
+  customOptions: Partial<StringOptions> = {}
 ) {
   return hexToString.bind(this)(customOptions, true);
 }
 
 export function oklabToString(
   this: OKLAB<number> & GetColor,
-  customOptions: Partial<Options> = {}
+  customOptions: Partial<StringOptions> = {}
 ) {
   const { options } = this;
   const stringOptions = merge(options, customOptions);
@@ -248,7 +248,7 @@ export function oklabToString(
 
 export function oklchToString(
   this: OKLCH<number> & GetColor,
-  customOptions: Partial<Options> = {}
+  customOptions: Partial<StringOptions> = {}
 ) {
   const { options } = this;
   const stringOptions = merge(options, customOptions);
@@ -268,7 +268,7 @@ export function oklchToString(
 
 export function cmykToString(
   this: CMYK<number> & GetColor,
-  customOptions: Partial<Options> = {}
+  customOptions: Partial<StringOptions> = {}
 ) {
   const { options } = this;
   const stringOptions = merge(options, customOptions);

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,7 +118,7 @@ export type ColorInput = MapOptionalAlpha<Color>;
 
 type AngleUnitType = `${AngleUnit}`;
 
-export interface Options {
+export interface StringOptions {
   legacy: boolean;
   spaced: boolean;
   angleUnit: AngleUnitType;
@@ -126,11 +126,15 @@ export interface Options {
   limitToColorSpace: boolean;
 }
 
-type ToStringColor = (options: Partial<Options>) => string;
+export interface GeneralOptions extends StringOptions {
+  cacheInput: boolean;
+}
+
+type ToStringColor = (options: Partial<StringOptions>) => string;
 
 export interface GetColor {
   toString: ToStringColor;
-  options: Options;
+  options: StringOptions;
 }
 
 export type ValuesArray = (number | string)[];

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -114,6 +114,14 @@ const redOklabExceeded = "oklab(0.65 0.26 0.15)";
 const blackCmyk = { c: 0, m: 0, y: 0, k: 1 };
 const blackCmykString = `device-cmyk(${blackCmyk.c} ${blackCmyk.m} ${blackCmyk.y} ${blackCmyk.k})`;
 
+const blueLch = { l: 32.3, c: 133.82, h: 306.29 };
+
+const blackHsl = { h: 0, s: 0, l: 0 };
+const blackHslSaturated = { h: 0, s: 90, l: 0 };
+
+const grayHwb = { h: 0, w: 80, b: 80 };
+const grayHwbModified = { h: 180, w: -79, b: -79 };
+
 describe("Class ColorTranslator", () => {
   it("should be defined", () => {
     expect(ColorTranslator).toBeDefined();
@@ -648,5 +656,67 @@ describe("Cmyk black support", () => {
   it("should not clamp rgb output", () => {
     const color = new ColorTranslator(blackCmyk);
     expect(color.cmyk.toString()).toEqual(blackCmykString);
+  });
+});
+
+describe("Lch hue fix", () => {
+  it("should return the same LCH color", () => {
+    const color = new ColorTranslator(blueLch);
+    expect(color.lch).toBeObject();
+    expect(round(color.lch.l)).toEqual(blueLch.l);
+    expect(round(color.lch.c)).toEqual(blueLch.c);
+    expect(round(color.lch.h)).toEqual(blueLch.h);
+    expect(round(color.lch.alpha)).toEqual(1);
+  });
+});
+
+describe("Cache input color", () => {
+  it("should ignore HSL saturation", () => {
+    const color = new ColorTranslator(blackHsl, { cacheInput: false });
+    expect(color.hsl.h).toEqual(blackHsl.h);
+    expect(color.hsl.s).toEqual(blackHsl.s);
+    expect(color.hsl.l).toEqual(blackHsl.l);
+    color.updateHsl(blackHslSaturated);
+    expect(color.hsl.h).toEqual(blackHsl.h);
+    expect(color.hsl.s).toEqual(blackHsl.s);
+    expect(color.hsl.l).toEqual(blackHsl.l);
+  });
+
+  it("should maintain HSL saturation", () => {
+    const color = new ColorTranslator(blackHsl);
+    expect(color.hsl.h).toEqual(blackHsl.h);
+    expect(color.hsl.s).toEqual(blackHsl.s);
+    expect(color.hsl.l).toEqual(blackHsl.l);
+    color.updateHsl(blackHslSaturated);
+    expect(color.hsl.h).toEqual(blackHslSaturated.h);
+    expect(color.hsl.s).toEqual(blackHslSaturated.s);
+    expect(color.hsl.l).toEqual(blackHslSaturated.l);
+  });
+
+  it("should modify HWB w/b values", () => {
+    const color = new ColorTranslator(grayHwb, { cacheInput: false });
+    expect(color.hwb.h).toEqual(grayHwbModified.h);
+    expect(color.hwb.w).toEqual(grayHwbModified.w);
+    expect(color.hwb.b).toEqual(grayHwbModified.b);
+    color.updateHwb(grayHwb);
+    expect(color.hwb.h).toEqual(grayHwbModified.h);
+    expect(color.hwb.w).toEqual(grayHwbModified.w);
+    expect(color.hwb.b).toEqual(grayHwbModified.b);
+    color.updateOptions({ cacheInput: true });
+    color.updateHwb(grayHwb);
+    expect(color.hwb.h).toEqual(grayHwb.h);
+    expect(color.hwb.w).toEqual(grayHwb.w);
+    expect(color.hwb.b).toEqual(grayHwb.b);
+  });
+
+  it("should maintain HWB w/b values", () => {
+    const color = new ColorTranslator(grayHwb);
+    expect(color.hwb.h).toEqual(grayHwb.h);
+    expect(color.hwb.w).toEqual(grayHwb.w);
+    expect(color.hwb.b).toEqual(grayHwb.b);
+    color.updateHwb(grayHwb);
+    expect(color.hwb.h).toEqual(grayHwb.h);
+    expect(color.hwb.w).toEqual(grayHwb.w);
+    expect(color.hwb.b).toEqual(grayHwb.b);
   });
 });


### PR DESCRIPTION
Added an option to keep stored the last color input. 

This helps when there is the need to maintain a coherent scale of colors in the same format, to avoid getting quite different values due to the translation back and forth to rgb